### PR TITLE
Fix ATM-Consulting/dolibarr_module_shippableorder#21, ajout de la réf cliente

### DIFF
--- a/class/shippableorder.class.php
+++ b/class/shippableorder.class.php
@@ -548,6 +548,7 @@ class ShippableOrder
 					$shipping->note_public = $this->order->note_public;
 					$shipping->note_private = $this->order->note_private;
 					$shipping->shipping_method_id = $this->order->shipping_method_id;
+					$shipping->ref_customer = $this->order->ref_client;
 
 					$shipping->weight_units = 0;
 					$shipping->weight = "NULL";
@@ -616,6 +617,7 @@ class ShippableOrder
 					$shipping->date_delivery = $this->order->date_livraison;
 					$shipping->note_public = $this->order->note_public;
 					$shipping->note_private = $this->order->note_private;
+					$shipping->ref_customer = $this->order->ref_client;
 
 					$shipping->weight_units = 0;
 					$shipping->weight = "NULL";


### PR DESCRIPTION
`ref_customer` était vide dans `llx_expedition`, c'était dommageable pour nous.