### PR TITLE
FIX : DA024022 - Affichage stock erroné

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@
 
 
 ## 2.3
-
+- FIX : Wrong display of the stock when option "Autoriser l'expédition même si pas assez de stock" is enabled *09/11/2023* 2.3.5
 - FIX : wrong js selector *28/02/2022* 2.3.4
 - FIX : Fix tooltip (wording and translation) for theorical stock on customer order *23/01/2022* 2.3.3
 - FIX : Compat PHP 8.1 V17  *17/01/2023* 2.3.2

--- a/class/shippableorder.class.php
+++ b/class/shippableorder.class.php
@@ -207,7 +207,6 @@ class ShippableOrder
 		{
 			$isShippable = 1;
 			$qtyShippable = $line->qty;
-			$line->stock = $line->qty;
 		}
         else if($stock <= 0 || $line->qty_toship <= 0) {
 			$isShippable = 0;

--- a/core/modules/modShippableOrder.class.php
+++ b/core/modules/modShippableOrder.class.php
@@ -61,7 +61,7 @@ class modShippableOrder extends DolibarrModules
 		$this->description = "Description of module ShippableOrder";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '2.3.4';
+		$this->version = '2.3.5';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \shippableorder\TechATM::getLastModuleVersionUrl($this);

--- a/core/modules/modShippableOrder.class.php
+++ b/core/modules/modShippableOrder.class.php
@@ -61,7 +61,7 @@ class modShippableOrder extends DolibarrModules
 		$this->description = "Description of module ShippableOrder";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
 
-		$this->version = '2.3.5';
+		$this->version = '2.3.6';
 		// Url to the file with your last numberversion of this module
 		require_once __DIR__ . '/../../class/techatm.class.php';
 		$this->url_last_version = \shippableorder\TechATM::getLastModuleVersionUrl($this);


### PR DESCRIPTION
## FIX : DA024022 - Affichage stock erroné

L'affichage du stock est erroné sur les lignes de facture lorsque la configuration "Autoriser l'expédition même si pas assez de stock" est activée. 

J'ai donc supprimé la partie rendant l'affichage erroné. 
Après test, avec cette configuration, il est tout de même possible d'expédier un produit dont le stock n'est normalement pas suffisant. 